### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
         - g++-6
 
 before_script:
+- ls -ltrF `which g++`
+- ls -ltrF `which g++-6`
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
 - p7zip -d boost_1_63_0.7z
 - pushd boost_1_63_0

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/dupes/make; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install p7zip; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated automake || brew upgrade automake; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtool; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated libtool || brew upgrade libtool; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gettext; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GNU_MAKE=gmake; else export GNU_MAKE=make; fi
 
@@ -49,6 +49,7 @@ before_script:
 - popd
 - git clone https://github.com/hunspell/hunspell.git
 - pushd hunspell
+- export LDFLAGS=-L/usr/local/opt/gettext/lib CPPFLAGS=-I/usr/local/opt/gettext/include
 - autoreconf -vfi
 - ./configure
 - $GNU_MAKE -kj 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: cpp
-compiler: g++
 
 addons:
     apt:
@@ -9,11 +8,13 @@ addons:
         packages:
         - p7zip
         - g++-6
-        - g++
+
+install:
+- mkdir latest-gcc
+- ln -s /usr/bin/g++-6 latest-gcc/g++
+- export PATH=$PWD/latest-gcc:$PATH
 
 before_script:
-- ls -ltrF `which g++`
-- ls -ltrF `which g++-6`
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
 - p7zip -d boost_1_63_0.7z
 - pushd boost_1_63_0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 - p7zip -d boost_1_63_0.7z > /dev/null
 - pushd boost_1_63_0
 - ./bootstrap.sh
-- ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
+- ./b2 -d0 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD
 - popd
 - git clone https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: false
+language: cpp
+
+addons:
+    apt:
+        packages:
+        - p7zip
+
+before_script:
+- wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
+- p7zip --decompress boost_1_63_0.7z
+- pushd boost_1_63_0
+- ./bootstrap.sh
+- ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
+- export BOOST_DIR=$PWD
+- popd
+- git clone https://github.com/google/googletest.git
+- pushd googletest/googletest/make
+- make -kj 2
+- export GTEST_DIR=$PWD
+- popd
+- git clone https://github.com/hunspell/hunspell.git
+- pushd hunspell
+- autoreconf -vfi
+- ./configure
+- make -kj 2
+- export HUNSPELL_DIR=$PWD
+- popd
+- git clone https://github.com/weidai11/cryptopp.git
+- pushd cryptopp
+- make -kj 2
+- export CRYPTOPP_DIR=$PWD
+- popd
+- wget 'https://downloads.sourceforge.net/project/wordlist/speller/2017.01.22/hunspell-en_US-2017.01.22.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fwordlist%2Ffiles%2Fspeller%2F2017.01.22%2F&ts=1486860415&use_mirror=vorboss' -O hunspell-en_US-2017.01.22.zip
+- unzip -d hunspell hunspell-en_US-2017.01.22.zip
+- rm hunspell-en_US-2017.01.22.zip
+
+script:
+- make -kj 2
+- export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
+- export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
+- ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: cpp
 
+branches:
+    only:
+    - master
+    - /^travis-.*/
+
 os:
 - linux
 - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 
 before_script:
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
-- p7zip --decompress boost_1_63_0.7z
+- p7zip -d boost_1_63_0.7z
 - pushd boost_1_63_0
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
-sudo: false
+sudo: required
 language: cpp
-
-compiler:
-- g++-6
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 before_script:
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
-- 7z x boost_1_63_0.7z
+- 7z x boost_1_63_0.7z > /dev/null
 - rm boost_1_63_0.7z
 - pushd boost_1_63_0
 - ./bootstrap.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: cpp
 
+compiler:
+- g++-6
+
 addons:
     apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: false
 language: cpp
 
+os:
+- linux
+- osx
+
+dist: trusty
+osx_image: xcode8.2
+
 addons:
     apt:
         sources:
@@ -9,12 +16,21 @@ addons:
         - p7zip
         - g++-6
 
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/dupes/make; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install p7zip; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated automake || brew upgrade automake; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtool; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gettext; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GNU_MAKE=gmake; else export GNU_MAKE=make; fi
+
 install:
 # Workaround for https://github.com/travis-ci/travis-ci/issues/3668
-- mkdir -p latest-gcc
-- ln -s /usr/bin/g++-6 latest-gcc/g++
-- ln -s /usr/bin/gcc-6 latest-gcc/gcc
-- export PATH=$PWD/latest-gcc:$PATH
+- mkdir -p latest-gcc-symlinks
+- ln -s /usr/bin/g++-6 latest-gcc-symlinks/g++
+- ln -s /usr/bin/gcc-6 latest-gcc-symlinks/gcc
+- export PATH=$PWD/latest-gcc-symlinks:$PATH
 - g++ --version
 
 before_script:
@@ -22,24 +38,24 @@ before_script:
 - p7zip -d boost_1_63_0.7z > /dev/null
 - pushd boost_1_63_0
 - ./bootstrap.sh
-- ./b2 -d0 --layout=system variant=release --with-system --with-date_time --with-regex
+- ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD
 - popd
 - git clone https://github.com/google/googletest.git
 - pushd googletest/googletest/make
-- make -kj 2
+- $GNU_MAKE -kj 2
 - export GTEST_DIR=$PWD/../..
 - popd
 - git clone https://github.com/hunspell/hunspell.git
 - pushd hunspell
 - autoreconf -vfi
 - ./configure
-- make -kj 2
+- $GNU_MAKE -kj 2
 - export HUNSPELL_DIR=$PWD
 - popd
 - git clone https://github.com/weidai11/cryptopp.git
 - pushd cryptopp
-- make -kj 2
+- $GNU_MAKE -kj 2
 - export CRYPTOPP_DIR=$PWD
 - popd
 - wget 'https://downloads.sourceforge.net/project/wordlist/speller/2017.01.22/hunspell-en_US-2017.01.22.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fwordlist%2Ffiles%2Fspeller%2F2017.01.22%2F&ts=1486860415&use_mirror=vorboss' -O hunspell-en_US-2017.01.22.zip
@@ -47,7 +63,7 @@ before_script:
 - rm hunspell-en_US-2017.01.22.zip
 
 script:
-- make -kj 2
+- $GNU_MAKE -kj 2
 - export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
 - export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
 - ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
         packages:
         - p7zip
         - g++-6
+        - g++
 
 before_script:
 - ls -ltrF `which g++`
@@ -23,7 +24,7 @@ before_script:
 - git clone https://github.com/google/googletest.git
 - pushd googletest/googletest/make
 - make -kj 2
-- export GTEST_DIR=$PWD
+- export GTEST_DIR=$PWD/../..
 - popd
 - git clone https://github.com/hunspell/hunspell.git
 - pushd hunspell
@@ -42,7 +43,7 @@ before_script:
 - rm hunspell-en_US-2017.01.22.zip
 
 script:
-- make -kj 2 CXX=g++-6
+- make -kj 2
 - export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
 - export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
 - ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: required
+sudo: false
 language: cpp
+compiler: g++
 
 addons:
     apt:
+        sources:
+        - ubuntu-toolchain-r-test
         packages:
         - p7zip
         - g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     apt:
         packages:
         - p7zip
+        - g++-6
 
 before_script:
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 - rm hunspell-en_US-2017.01.22.zip
 
 script:
-- make -kj 2
+- make -kj 2 CXX=g++-6
 - export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
 - export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
 - ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - p7zip
+        - p7zip-full
         - g++-6
 
 before_install:
@@ -35,7 +35,8 @@ install:
 
 before_script:
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
-- p7zip -d boost_1_63_0.7z > /dev/null
+- 7z x boost_1_63_0.7z
+- rm boost_1_63_0.7z
 - pushd boost_1_63_0
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,16 @@ addons:
         - g++-6
 
 install:
-- mkdir latest-gcc
+# Workaround for https://github.com/travis-ci/travis-ci/issues/3668
+- mkdir -p latest-gcc
 - ln -s /usr/bin/g++-6 latest-gcc/g++
+- ln -s /usr/bin/gcc-6 latest-gcc/gcc
 - export PATH=$PWD/latest-gcc:$PATH
+- g++ --version
 
 before_script:
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
-- p7zip -d boost_1_63_0.7z
+- p7zip -d boost_1_63_0.7z > /dev/null
 - pushd boost_1_63_0
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Cryptopals
 
-<a href="https://scan.coverity.com/projects/tanzislam-cryptopals">
+<a href="https://travis-ci.org/tanzislam/cryptopals">
+  <img alt="Build Status"
+       src="https://travis-ci.org/tanzislam/cryptopals.svg?branch=master"/>
+</a> <a href="https://scan.coverity.com/projects/tanzislam-cryptopals">
   <img alt="Coverity Scan Build Status"
        src="https://scan.coverity.com/projects/10143/badge.svg"/>
 </a>


### PR DESCRIPTION
Add a `.travis.yml` file for running continuous integration builds with Travis on container-based Ubuntu 14.04 (using GCC 6.2) and macOS Sierra (using the system-provided Clang). Also add a build status badge to the `README.md`.