### PR TITLE
Add Coverity Scan automation to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ addons:
         packages:
         - p7zip-full
         - g++-6
+    coverity_scan:
+        project:
+            name: $TRAVIS_REPO_SLUG
+            version: $TRAVIS_COMMIT
+            description: Cryptopals
+        build_command: make -k
+        branch_pattern: coverity_scan
 
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
         project:
             name: $TRAVIS_REPO_SLUG
             version: $TRAVIS_COMMIT
-        build_command: make -k
+        build_command: bash -c 'if [[ "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]; then $GNU_MAKE -k; else true; fi'
         branch_pattern: travis-coverity_scan
 
 before_install:
@@ -78,12 +78,7 @@ before_script:
 - rm hunspell-en_US-2017.01.22.zip
 
 script:
-# https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-216604414
-- |
-    if [[ "$COVERITY_SCAN_BRANCH" != "1" || "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]
-    then
-        $GNU_MAKE -kj 2
-        export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
-        export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
-        ./test
-    fi
+- $GNU_MAKE -kj 2
+- export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
+- export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
+- ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ addons:
         - p7zip-full
         - g++-6
     coverity_scan:
+        # COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL should be set
+        # in Travis settings. They depend on repo owner so aren't included here.
         project:
             name: $TRAVIS_REPO_SLUG
             version: $TRAVIS_COMMIT
-            description: Cryptopals
         build_command: make -k
         branch_pattern: travis-coverity_scan
 
@@ -46,6 +47,8 @@ install:
 - g++ --version
 
 before_script:
+# https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-216604414
+- if [[ "$COVERITY_SCAN_BRANCH" == "1" && "${TRAVIS_JOB_NUMBER##*.}" != "1" ]]; then exit 0; fi
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
 - 7z x boost_1_63_0.7z > /dev/null
 - rm boost_1_63_0.7z
@@ -77,6 +80,8 @@ before_script:
 - rm hunspell-en_US-2017.01.22.zip
 
 script:
+# https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-216604414
+- if [[ "$COVERITY_SCAN_BRANCH" == "1" && "${TRAVIS_JOB_NUMBER##*.}" != "1" ]]; then exit 0; fi
 - $GNU_MAKE -kj 2
 - export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
 - export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ addons:
         project:
             name: $TRAVIS_REPO_SLUG
             version: $TRAVIS_COMMIT
-        build_command: bash -c 'if [[ "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]; then $GNU_MAKE -k; else true; fi'
-        branch_pattern: travis-coverity_scan
+        # Coverity refuses to run on OSX due to System Integrity Protection
+        # being enabled, so we need no hackery here to limit it to Linux only.
+        build_command: $GNU_MAKE -k
+        branch_pattern: master
 
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
             version: $TRAVIS_COMMIT
             description: Cryptopals
         build_command: make -k
-        branch_pattern: coverity_scan
+        branch_pattern: travis-coverity_scan
 
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ install:
 - g++ --version
 
 before_script:
-# https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-216604414
-- if [[ "$COVERITY_SCAN_BRANCH" == "1" && "${TRAVIS_JOB_NUMBER##*.}" != "1" ]]; then exit 0; fi
 - wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
 - 7z x boost_1_63_0.7z > /dev/null
 - rm boost_1_63_0.7z
@@ -81,8 +79,11 @@ before_script:
 
 script:
 # https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-216604414
-- if [[ "$COVERITY_SCAN_BRANCH" == "1" && "${TRAVIS_JOB_NUMBER##*.}" != "1" ]]; then exit 0; fi
-- $GNU_MAKE -kj 2
-- export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
-- export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
-- ./test
+- |
+    if [[ "$COVERITY_SCAN_BRANCH" != "1" || "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]
+    then
+        $GNU_MAKE -kj 2
+        export HUNSPELL_AFFIX_PATH=$HUNSPELL_DIR/en_US.aff
+        export HUNSPELL_DICT_PATH=$HUNSPELL_DIR/en_US.dic
+        ./test
+    fi


### PR DESCRIPTION
Add the Coverity Scan add-on to the `.travis.yml` file. Only content-specific settings are included; owner-specific settings are expected to be supplied as secured environment variables.

The Coverity Scan is effectively executed only on Linux, due to having conflicts with the System Integrity Protection feature on OSX. This suits our use case perfectly, as we want Coverity Scan to run only on one of the matrix jobs.