### PR TITLE
Use Modular Boost for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ before_script:
 - pushd boost
 - git submodule --quiet update --init --recursive
 - ./bootstrap.sh
-- ./b2 --layout=system variant=release headers --with-system --with-date_time --with-regex
+- ./b2 headers
+- ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD
 - popd
 - git clone https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 - pushd boost
 - git submodule update --init --recursive
 - ./bootstrap.sh
-- ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
+- ./b2 --layout=system variant=release headers --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD
 - popd
 - git clone https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 before_script:
 - git clone https://github.com/boostorg/boost.git
 - pushd boost
-- git submodule update --init --recursive --jobs 2
+- git submodule update --init --recursive
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 before_script:
 - git clone https://github.com/boostorg/boost.git
 - pushd boost
-- git submodule update --init --recursive
+- git submodule --quiet update --init --recursive
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release headers --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 before_script:
 - git clone https://github.com/boostorg/boost.git
 - pushd boost
-- git submodule update --init
+- git submodule update --init --recursive --jobs 2
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - p7zip-full
         - g++-6
     coverity_scan:
         # COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL should be set
@@ -34,7 +33,6 @@ addons:
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/dupes/make; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install p7zip; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated automake || brew upgrade automake; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated libtool || brew upgrade libtool; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gettext; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,9 @@ install:
 - g++ --version
 
 before_script:
-- wget 'https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.63.0%2Fboost_1_63_0.7z%2Fdownload%3Fuse_mirror%3Dautoselect&ts=1486852109&use_mirror=vorboss' -O boost_1_63_0.7z
-- 7z x boost_1_63_0.7z > /dev/null
-- rm boost_1_63_0.7z
-- pushd boost_1_63_0
+- git clone https://github.com/boostorg/boost.git
+- pushd boost
+- git submodule update --init
 - ./bootstrap.sh
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex
 - export BOOST_DIR=$PWD


### PR DESCRIPTION
Instead of downloading a fixed Boost release from a specific SourceForge mirror, use the Modular Boost GitHub repo.