### PR TITLE
Disable quiet mode on Boost submodule update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 before_script:
 - git clone https://github.com/boostorg/boost.git
 - pushd boost
-- git submodule --quiet update --init --recursive
+- git submodule update --init --recursive
 - ./bootstrap.sh
 - ./b2 headers
 - ./b2 --layout=system variant=release --with-system --with-date_time --with-regex


### PR DESCRIPTION
This step takes a long time and the MacOS build on Travis times out if no output is generated for 10 minutes.