### PR TITLE
Add configuration for lgtm.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,30 @@
+path_classifiers:
+    test:
+        - "*/*/test_*.cpp"
+    docs:
+        - README.md
+        - LICENSE.txt
+
+extraction:
+    cpp:
+        prepare:
+            packages:
+                - g++-7
+        after_prepare:
+            - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
+            - ln -s /usr/bin/g++-7 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
+            - ln -s /usr/bin/gcc-7 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
+            - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH
+            - export GNU_MAKE=make
+        configure:
+            command:
+                - pushd $LGTM_WORKSPACE
+                - $LGTM_SRC/prepare_deps
+                - popd
+                - export BOOST_DIR=$LGTM_WORKSPACE/boost
+                - export GTEST_DIR=$LGTM_WORKSPACE/googletest
+                - export HUNSPELL_DIR=$LGTM_WORKSPACE/hunspell
+                - export CRYPTOPP_DIR=$LGTM_WORKSPACE/cryptopp
+        index:
+            build_command:
+                - $GNU_MAKE -k

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,68 +86,11 @@ before_install:
 - g++ --version
 
 install:
-# The Cache plugin creates the directories, so we can't use [[ ! -d $dir ]] here
-- >-
-    if [[ ! -x boost/bootstrap.sh ]];
-    then
-        git clone https://github.com/boostorg/boost.git;
-    fi
-- pushd boost
-- git pull --prune
-- git submodule update --init --recursive
-- ./bootstrap.sh
-- ./b2 headers
-- ./b2 --layout=system variant=release -j 2 --with-system
-- export BOOST_DIR=$PWD
-- popd
-- >-
-    if [[ ! -f googletest/googletest/make/Makefile &&
-          ! -f googletest/googletest/make/GNUmakefile ]];
-    then
-        git clone https://github.com/google/googletest.git;
-    fi
-- pushd googletest
-- git pull --prune
-- git submodule update --init --recursive
-- pushd googletest/make
-- $GNU_MAKE -kj 2
-- popd
-- export GTEST_DIR=$PWD
-- popd
-- >-
-    if [[ ! -f hunspell/configure.ac ]];
-    then
-        git clone https://github.com/hunspell/hunspell.git;
-    fi
-- pushd hunspell
-- git pull --prune
-- git submodule update --init --recursive
-- export LDFLAGS=-L/usr/local/opt/gettext/lib
-- export CPPFLAGS=-I/usr/local/opt/gettext/include
-- autoreconf -vfi
-- ./configure
-- $GNU_MAKE -kj 2
-- export HUNSPELL_DIR=$PWD
-- popd
-- >-
-    if [[ ! -f cryptopp/GNUmakefile ]];
-    then
-        git clone https://github.com/weidai11/cryptopp.git;
-    fi
-- pushd cryptopp
-- git pull --prune
-- git submodule update --init --recursive
-- $GNU_MAKE deps
-- $GNU_MAKE -kj 2
-- export CRYPTOPP_DIR=$PWD
-- popd
-- "wget \
-'https://downloads.sourceforge.net/project/wordlist/speller/2017.01.22/\
-hunspell-en_US-2017.01.22.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2F\
-wordlist%2Ffiles%2Fspeller%2F2017.01.22%2F&ts=1486860415&use_mirror=vorboss' \
--O hunspell-en_US-2017.01.22.zip"
-- unzip -o -d hunspell hunspell-en_US-2017.01.22.zip
-- rm hunspell-en_US-2017.01.22.zip
+- ./prepare_deps
+- export BOOST_DIR=$PWD/boost
+- export GTEST_DIR=$PWD/googletest
+- export HUNSPELL_DIR=$PWD/hunspell
+- export CRYPTOPP_DIR=$PWD/cryptopp
 
 script:
 - >-

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ You may need to install additional packages beyond the ones bundled with the
 default installation. Check the respective documentation for guidance on how to
 locate and install packages.
 
+Once the packages are installed, the "from source" dependency libraries can be
+downloaded and built using the `prepare_deps` script, especially in CI jobs.
+
 Although my development environment is in Windows (primarily [Notepad++](
 https://notepad-plus-plus.org/) enhanced with some humble [NppExec](
 https://sourceforge.net/projects/npp-plugins/files/NppExec/) scripts), I tried

--- a/prepare_deps
+++ b/prepare_deps
@@ -1,0 +1,80 @@
+#!/bin/bash -x
+
+# Prerequisites:
+# - Changed to relevant directory for downloading and building dependencies.
+# - Latest GCC ('gcc' and 'g++') available in PATH.
+# - Relatively modern Git (with support for submodules) available in PATH.
+# - Caller will export BOOST_DIR, GTEST_DIR, HUNSPELL_DIR and CRYPTOPP_DIR.
+# - Environment variables:
+#   - GNU_MAKE: Executable name of GNU Make (at least v4.1).
+
+function build_boost {
+    # The Travis Cache plugin creates the directories beforehand, so we can't
+    # use [[ ! -d $dir ]] here
+    if [[ ! -x boost/bootstrap.sh ]]
+    then
+        git clone https://github.com/boostorg/boost.git
+    fi
+    pushd boost
+    git pull --prune
+    git submodule update --init --recursive
+    ./bootstrap.sh
+    ./b2 headers
+    ./b2 --layout=system variant=release -j 2 --with-system
+}
+
+function build_gtest {
+    if [[ ! -f googletest/googletest/make/Makefile &&
+          ! -f googletest/googletest/make/GNUmakefile ]]
+    then
+        git clone https://github.com/google/googletest.git
+    fi
+    pushd googletest
+    git pull --prune
+    git submodule update --init --recursive
+    pushd googletest/make
+    $GNU_MAKE -kj 2
+}
+
+function build_hunspell {
+    if [[ ! -f hunspell/configure.ac ]]
+    then
+        git clone https://github.com/hunspell/hunspell.git
+    fi
+    pushd hunspell
+    git pull --prune
+    git submodule update --init --recursive
+    export LDFLAGS=-L/usr/local/opt/gettext/lib
+    export CPPFLAGS=-I/usr/local/opt/gettext/include
+    autoreconf -vfi
+    ./configure
+    $GNU_MAKE -kj 2
+}
+
+function build_cryptopp {
+    if [[ ! -f cryptopp/GNUmakefile ]]
+    then
+        git clone https://github.com/weidai11/cryptopp.git
+    fi
+    pushd cryptopp
+    git pull --prune
+    git submodule update --init --recursive
+    $GNU_MAKE deps
+    $GNU_MAKE -kj 2
+}
+
+function download_scowl_for_hunspell {
+    url='https://downloads.sourceforge.net/project/wordlist/speller/2017.01.22/'
+    url+='hunspell-en_US-2017.01.22.zip?r=https%3A%2F%2Fsourceforge.net%2F'
+    url+='projects%2Fwordlist%2Ffiles%2Fspeller%2F2017.01.22%2F&ts=1486860415'
+    url+='&use_mirror=vorboss'
+    wget "$url" -O hunspell-en_US-2017.01.22.zip
+    unzip -o -d hunspell hunspell-en_US-2017.01.22.zip
+    rm hunspell-en_US-2017.01.22.zip
+}
+
+build_boost &
+build_gtest &
+build_hunspell &
+build_cryptopp &
+wait


### PR DESCRIPTION
Add a `.lgtm.yml` file for analysis with lgtm.com. Also factor out the dependency-build logic into a new `prepare_deps` script for reuse.

Implements #13, except that lgtm.com's C++ support is not yet generally released.