### PR TITLE
Fix OpenSSL build in Windows MinGW-w64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,7 @@ before_install:
         $msys2 pacman --sync --noconfirm --needed \
                 autoconf \
                 automake \
+                make \
                 mingw-w64-x86_64-libtool \
                 mingw-w64-x86_64-toolchain \
                 perl \
@@ -148,8 +149,8 @@ before_install:
         taskkill //IM gpg-agent.exe //F
         export CPPFLAGS=-D__USE_MINGW_ANSI_STDIO=1
         export PATH=/C/tools/msys64/mingw64/bin:$PATH
-        export GNU_MAKE=mingw32-make
-        export MAKE=mingw32-make
+        export GNU_MAKE=/C/tools/msys64/usr/bin/make
+        export MAKE=$GNU_MAKE
         export AR=gcc-ar
         export RANLIB=gcc-ranlib
         export COVERITY_SCAN_BRANCH_PATTERN=disable_coverity_scan
@@ -158,7 +159,7 @@ before_install:
 - export BAZEL=bazel
 - export GIT=git
 - g++ --version
-- $GNU_MAKE --version
+- $shell $GNU_MAKE --version
 - $GIT --version
 
 install:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ To build these solutions you will need:
    overrides to use GCC:
 
        CC=gcc CXX=g++ ./config
-       mingw32-make AR=gcc-ar RANLIB=gcc-ranlib
+       make AR=gcc-ar RANLIB=gcc-ranlib
+
+   - On Windows / MinGW-w64 I had to install the MSYS2 `make.exe`, because the
+     generated `Makefile` contains Unix-style full paths that `mingw32-make.exe`
+     cannot understand.
 
    - On macOS, the dynamic library search mechanism cannot be directed to find
      transitive dependencies (e.g. `libcrypto.dylib`, needed by `libssl.dylib`)


### PR DESCRIPTION
OpenSSL's generated `Makefile` now needs a `make` that can handle POSIX-style full pathnames. This apparently started failing [between 25th and 28th July 2020](https://travis-ci.org/github/tanzislam/cryptopals/jobs/712025594#L939-L942) but I could not discern why.