### PR TITLE
Use system-default GCC and latest Bazel for LGTM build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -36,6 +36,7 @@ extraction:
                                     -name bazelisk-linux_amd64 \
                                     -print \
                                     -quit)
+            - echo "startup --server_javabase=$SEMMLE_JAVA_HOME" >> ~/.bazelrc
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -36,6 +36,7 @@ extraction:
                                     -name bazelisk-linux_amd64 \
                                     -print \
                                     -quit)
+            # LGTM's server uses a MITM proxy: https://discuss.lgtm.com/t/598/14
             - |-
                 $SEMMLE_JAVA_HOME/bin/keytool -importcert \
                                               -trustcacerts \
@@ -43,12 +44,11 @@ extraction:
                                               -file $NODE_EXTRA_CA_CERTS \
                                               -alias bazel \
                                               -keystore $(pwd)/bazel \
-                                              -storepass test12
+                                              -storepass 6chars
             - |-
                 echo startup \
                      --host_jvm_args=-Djavax.net.ssl.trustStore=$(pwd)/bazel \
-                     --host_jvm_args=-Djavax.net.ssl.trustStorePassword=test12 \
-                     --host_jvm_args=-Djavax.net.debug=ssl,keymanager \
+                     --host_jvm_args=-Djavax.net.ssl.trustStorePassword=6chars \
                      > ~/.bazelrc
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,7 +29,12 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL=`find . -type f -name bazelisk-linux_amd64 -print -quit`
+            - export BAZEL=$(find $(pwd) \
+                                  -type f \
+                                  -executable \
+                                  -name bazelisk-linux_amd64 \
+                                  -print \
+                                  -quit)
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -30,12 +30,12 @@ extraction:
             - export GNU_MAKE=make
             - export GIT=true
             - >-
-              export BAZEL=$(find $(pwd)
-                                  -type f
-                                  -executable
-                                  -name bazelisk-linux_amd64
-                                  -print
-                                  -quit)
+                export BAZEL=$(find $(pwd)
+                                    -type f
+                                    -executable
+                                    -name bazelisk-linux_amd64
+                                    -print
+                                    -quit)
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,12 +29,12 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - >-
-                export BAZEL=$(find $(pwd)
-                                    -type f
-                                    -executable
-                                    -name bazelisk-linux_amd64
-                                    -print
+            - |-
+                export BAZEL=$(find $(pwd) \
+                                    -type f \
+                                    -executable \
+                                    -name bazelisk-linux_amd64 \
+                                    -print \
                                     -quit)
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,7 +29,7 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL=bazelisk
+            - export BAZEL="npm run bazelisk --"
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -43,11 +43,11 @@ extraction:
                                               -file $NODE_EXTRA_CA_CERTS \
                                               -alias bazel \
                                               -keystore bazel.jks \
-                                              -storepass test
+                                              -storepass test12
             - |-
                 echo startup \
                      --host_jvm_args=-Djavax.net.ssl.trustStore=bazel.jks \
-                     --host_jvm_args=-Djavax.net.ssl.trustStorePassword=test \
+                     --host_jvm_args=-Djavax.net.ssl.trustStorePassword=test12 \
                      > ~/.bazelrc
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,7 +29,7 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL="npm run bazelisk --"
+            - export BAZEL=$LGTM_SRC/node_modules/bin/bazelisk-linux_amd64
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell
@@ -37,6 +37,7 @@ extraction:
             - export OPENSSL_DIR=$LGTM_SRC/openssl
         configure:
             command:
+                - find . -type f -name bazelisk-linux_amd64
                 - ./prepare_deps
         index:
             build_command:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -17,6 +17,7 @@ extraction:
         prepare:
             packages:
                 - g++
+                - npm
                 - pkg-config
                 - python3
                 - unzip

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -42,12 +42,13 @@ extraction:
                                               -noprompt \
                                               -file $NODE_EXTRA_CA_CERTS \
                                               -alias bazel \
-                                              -keystore bazel.jks \
+                                              -keystore $(pwd)/bazel \
                                               -storepass test12
             - |-
                 echo startup \
-                     --host_jvm_args=-Djavax.net.ssl.trustStore=bazel.jks \
+                     --host_jvm_args=-Djavax.net.ssl.trustStore=$(pwd)/bazel \
                      --host_jvm_args=-Djavax.net.ssl.trustStorePassword=test12 \
+                     --host_jvm_args=-Djavax.net.debug=ssl,keymanager \
                      > ~/.bazelrc
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,11 +29,12 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL=$(find $(pwd) \
-                                  -type f \
-                                  -executable \
-                                  -name bazelisk-linux_amd64 \
-                                  -print \
+            - >-
+              export BAZEL=$(find $(pwd)
+                                  -type f
+                                  -executable
+                                  -name bazelisk-linux_amd64
+                                  -print
                                   -quit)
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -16,28 +16,19 @@ extraction:
     cpp:
         prepare:
             packages:
-                - g++-6
+                - g++
                 - pkg-config
                 - python3
                 - unzip
                 - zip
                 - zlib1g-dev
         after_prepare:
-            - urlbase="https://github.com/bazelbuild/bazel/releases/download"
-            - version=0.27.0
-            - filename="bazel-${version}-installer-linux-x86_64.sh"
-            - wget "${urlbase}/${version}/${filename}" -O $filename
-            - chmod +x $filename
-            - ./$filename --user
-            - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
-            - ln -s /usr/bin/g++-6 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
-            - ln -s /usr/bin/gcc-6 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
-            - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH:$HOME/bin
-            - export AR=gcc-ar-6
-            - export RANLIB=gcc-ranlib-6
+            - npm install -g @bazel/bazelisk
+            - export AR=gcc-ar
+            - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL=bazel
+            - export BAZEL=bazelisk
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -36,7 +36,19 @@ extraction:
                                     -name bazelisk-linux_amd64 \
                                     -print \
                                     -quit)
-            - echo "startup --server_javabase=$SEMMLE_JAVA_HOME" >> ~/.bazelrc
+            - |-
+                $SEMMLE_JAVA_HOME/bin/keytool -importcert \
+                                              -trustcacerts \
+                                              -noprompt \
+                                              -file $NODE_EXTRA_CA_CERTS \
+                                              -alias bazel \
+                                              -keystore bazel.jks \
+                                              -storepass test
+            - |-
+                echo startup \
+                     --host_jvm_args=-Djavax.net.ssl.trustStore=bazel.jks \
+                     --host_jvm_args=-Djavax.net.ssl.trustStorePassword=test \
+                     > ~/.bazelrc
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell
@@ -44,7 +56,6 @@ extraction:
             - export OPENSSL_DIR=$LGTM_SRC/openssl
         configure:
             command:
-                - env
                 - ./prepare_deps
         index:
             build_command:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,7 +29,7 @@ extraction:
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make
             - export GIT=true
-            - export BAZEL=$LGTM_SRC/node_modules/bin/bazelisk-linux_amd64
+            - export BAZEL=`find . -type f -name bazelisk-linux_amd64 -print -quit`
             - export BOOST_DIR=$LGTM_SRC/boost
             - export GTEST_DIR=$LGTM_SRC/googletest
             - export HUNSPELL_DIR=$LGTM_SRC/hunspell
@@ -37,7 +37,6 @@ extraction:
             - export OPENSSL_DIR=$LGTM_SRC/openssl
         configure:
             command:
-                - find . -type f -name bazelisk-linux_amd64
                 - ./prepare_deps
         index:
             build_command:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -24,7 +24,7 @@ extraction:
                 - zip
                 - zlib1g-dev
         after_prepare:
-            - npm install -g @bazel/bazelisk
+            - npm install @bazel/bazelisk
             - export AR=gcc-ar
             - export RANLIB=gcc-ranlib
             - export GNU_MAKE=make

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -43,6 +43,7 @@ extraction:
             - export OPENSSL_DIR=$LGTM_SRC/openssl
         configure:
             command:
+                - env
                 - ./prepare_deps
         index:
             build_command:


### PR DESCRIPTION
Current installation of GCC 6 was failing due to [Ubuntu version upgrade](https://discuss.lgtm.com/t/1950).